### PR TITLE
adding __STDC_FORMAT_MACROS for msys2

### DIFF
--- a/src/HPVPlayer.cpp
+++ b/src/HPVPlayer.cpp
@@ -4,6 +4,8 @@
 #include "lz4.h"
 #include "lz4hc.h"
 
+#define __STDC_FORMAT_MACROS
+
 namespace HPV {
 
     static std::string HPVCompressionTypeStrings[] =


### PR DESCRIPTION
The line

`#define __STDC_FORMAT_MACROS`

seems necessary to compile under windows 10 / msys2
(otherwise, I got the `expected ')' before 'PRId64'` )